### PR TITLE
[fix] using comma to seperate dependencies for generated class

### DIFF
--- a/lib/services/code_generator/code_generator_service.dart
+++ b/lib/services/code_generator/code_generator_service.dart
@@ -84,7 +84,7 @@ class CodeGeneratorService {
 
       final dependenciesUnique = [
         ...{...dependencies}
-      ].join('\n');
+      ].join(', ');
 
       totalDependenciesCounter += dependenciesUnique.length;
       final factoryConstructorName = mode.camelCase().escapeKeywords();


### PR DESCRIPTION
before:
```dart
factory Tokens.light(Primitives primitives
Tokens tokens) => Tokens(
```

after:
```dart
factory Tokens.light(Primitives primitives, Tokens tokens) => Tokens(
```